### PR TITLE
Fixes flyout menu hover shifting

### DIFF
--- a/less/palette.less
+++ b/less/palette.less
@@ -223,7 +223,9 @@
       }
       > a {
         color: @kie-palette-flyout-item-color;
-
+        &:before {
+          width: 0;
+        }
         //background-color: inherit;
         color: @kie-palette-color;
         font-weight: @kie-palette-font-weight;


### PR DESCRIPTION
The shift on the flyout menu was caused by adding space for the blue line on a selected item on the main palette. This sets that width to 0 so that no shift occurs on the flyout.