### PR TITLE
Fixes the scroll shadow

### DIFF
--- a/css/kie-main-caseonly.css
+++ b/css/kie-main-caseonly.css
@@ -19639,7 +19639,7 @@ ul.kie-nav-wizard .active ~ li:after {
 .kie-scrollbox {
   overflow-y: hidden;
   max-height: 15em;
-  background: linear-gradient(#fff, rgba(255, 255, 255, 0)) 0 100%, linear-gradient(rgba(255, 255, 255, 0), #fff) 0 100%, /* Shadows */ linear-gradient(#f5f5f5, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #f5f5f5) 0 100%;
+  background: linear-gradient(#fff, rgba(255, 255, 255, 0)) 100% 0, linear-gradient(rgba(255, 255, 255, 0), #fff) 0 100%, /* Shadows */ linear-gradient(#f5f5f5, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #f5f5f5) 0 100%;
   background-repeat: no-repeat;
   background-color: #fff;
   background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;

--- a/css/kie-main-kw.css
+++ b/css/kie-main-kw.css
@@ -19639,7 +19639,7 @@ ul.kie-nav-wizard .active ~ li:after {
 .kie-scrollbox {
   overflow-y: hidden;
   max-height: 15em;
-  background: linear-gradient(#fff, rgba(255, 255, 255, 0)) 0 100%, linear-gradient(rgba(255, 255, 255, 0), #fff) 0 100%, /* Shadows */ linear-gradient(#f5f5f5, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #f5f5f5) 0 100%;
+  background: linear-gradient(#fff, rgba(255, 255, 255, 0)) 100% 0, linear-gradient(rgba(255, 255, 255, 0), #fff) 0 100%, /* Shadows */ linear-gradient(#f5f5f5, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #f5f5f5) 0 100%;
   background-repeat: no-repeat;
   background-color: #fff;
   background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;

--- a/less/case-overview-template.less
+++ b/less/case-overview-template.less
@@ -174,7 +174,7 @@
   //IMPORTANT: can change to overflow-y: auto to see how the scroll shadows work. JS will have to manually set the scroll of the list
   overflow-y: hidden;
   max-height: 15em;
-  background: /* Shadow covers */ linear-gradient(@color-pf-white, rgba(255, 255, 255, 0)) 0 100%, //top
+  background: /* Shadow covers */ linear-gradient(@color-pf-white, rgba(255, 255, 255, 0)) 100% 0, //top
   linear-gradient(rgba(255, 255, 255, 0), @color-pf-white) 0 100%, //bottom
     /* Shadows */ linear-gradient(@color-pf-black-150, rgba(255, 255, 255, 0)),
   linear-gradient(rgba(255, 255, 255, 0), @color-pf-black-150) 0 100%;


### PR DESCRIPTION
On some of the case view widgets, a shadow is used to indicate that there is something scrolled off the edge. This fixes an error in the top shadow.